### PR TITLE
[FIX] FIx always uppercase in search material field

### DIFF
--- a/resources/views/material_user/index.blade.php
+++ b/resources/views/material_user/index.blade.php
@@ -66,6 +66,10 @@
         border:none !important;
         float:none !important;
     }
+
+    #search_material {
+        text-transform: uppercase;
+    }
 </style>
 <section class="content">
        <div class="row">


### PR DESCRIPTION
What is this changes fixed?
show uppercase text in search material filed
Screeshot?
![screenshot from 2019-01-30 11-40-49](https://user-images.githubusercontent.com/46434308/51958798-6036d500-2484-11e9-80af-8b7f35c34979.png)